### PR TITLE
Add jQuery dependency

### DIFF
--- a/gist_embed.libraries.yml
+++ b/gist_embed.libraries.yml
@@ -12,3 +12,5 @@ ge-js:
   css:
       theme:
         css/gist-embed.css: {}
+  dependencies:
+    - core/jquery


### PR DESCRIPTION
On drupalvmgenerator.com, I noticed that the gist on the Homepage wasn't loading for anonymous users.

In the Chome dev tools console, I saw that jQuery was not defined. This PR adds jQuery as a dependency which fixes the issue after a cache rebuild.

![screen shot 2016-08-05 at 11 34 05](https://cloud.githubusercontent.com/assets/339813/17434726/2385065a-5b04-11e6-88bf-2c0ae763ef60.png)
